### PR TITLE
Added a logic not to append the port number in case of debugging

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractTicketValidationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractTicketValidationFilter.java
@@ -281,11 +281,18 @@ public abstract class AbstractTicketValidationFilter extends AbstractCasFilter {
 				if (pos > 0 && pos < serverName.length() - 1) {
 					serverName = String.format("accounts.%s", serverName.substring(pos + 1));
 				}
+				boolean debug = false;
+				if (request.getParameterMap().containsKey("debug")) {
+					debug = Boolean.parseBoolean(request.getParameter("debug"));
+				}
 				final StringBuilder builder = new StringBuilder();
 				builder
 					.append(request.getScheme()).append("://")
-					.append(serverName)
-					.append(":").append(request.getServerPort())
+					.append(serverName);
+				if (!debug) {
+					builder.append(":").append(request.getServerPort());	
+				}
+				builder
 					.append("/auth/oauth2.0/profile?access_token=")
 					.append(accessToken);
 				final String serverResponse = CommonUtils.getResponseFromServer(new URL(builder.toString()),


### PR DESCRIPTION
* When using the local OneTeam, its port number is appended to the internal URL unnecessarily.
* Added a logic not to append the port number in case of debugging.