### PR TITLE
Set header for CAS server login URL

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -242,6 +242,9 @@ public class AuthenticationFilter extends AbstractCasFilter {
 
         final String urlToRedirectTo = CommonUtils.constructRedirectUrl(modifiedCasServerLoginUrl,
                 getProtocol().getServiceParameterName(), modifiedServiceUrl, this.renew, this.gateway);
+        
+        // Set header values for clients to handle AJAX response.
+        response.setHeader("Cas-Server-Login-Url", modifiedCasServerLoginUrl);
 
         logger.debug("redirecting to \"{}\"", urlToRedirectTo);
         this.authenticationRedirectStrategy.redirect(request, response, urlToRedirectTo);


### PR DESCRIPTION
* Set header with CAS server login URL for clients to handle responses in AJAX.